### PR TITLE
Combined dependency updates (2022-12-04)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-            	<version>2.7.5</version>
+            	<version>2.7.6</version>
 				<executions>
 			        <execution>
 						<id>build-info</id>
@@ -505,7 +505,7 @@
 			<plugin>
             	<groupId>org.springframework.boot</groupId>
             	<artifactId>spring-boot-maven-plugin</artifactId>
-            	<version>2.7.5</version>
+            	<version>2.7.6</version>
             	<configuration>
             	    <mainClass>giis.demo.descuento.DescuentoApplication</mainClass>
             	    <classifier>deploy</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.5</version>
+		<version>2.7.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Includes these updates:
- [Bump spring-boot-maven-plugin from 2.7.5 to 2.7.6](https://github.com/javiertuya/samples-test-spring/pull/91)
- [Bump spring-boot-starter-parent from 2.7.5 to 2.7.6](https://github.com/javiertuya/samples-test-spring/pull/92)