### PR TITLE
Combined dependency updates (2022-12-16)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.6.1
+        uses: mikepenz/action-junit-report@v3.6.2
         with:
           check_name: test-report (ut, it)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -233,7 +233,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.6.1
+        uses: mikepenz/action-junit-report@v3.6.2
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.7.0</selenium.version>
+		<selenium.version>4.7.2</selenium.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.6.1 to 3.6.2](https://github.com/javiertuya/samples-test-spring/pull/96)
- [Bump selenium-java from 4.7.0 to 4.7.2](https://github.com/javiertuya/samples-test-spring/pull/97)