### PR TITLE
Combined dependency updates (2022-12-26)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.6.2
+        uses: mikepenz/action-junit-report@v3.7.0
         with:
           check_name: test-report (ut, it)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -272,7 +272,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.6.2
+        uses: mikepenz/action-junit-report@v3.7.0
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -333,7 +333,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.6.2
+        uses: mikepenz/action-junit-report@v3.7.0
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-            	<version>2.7.6</version>
+            	<version>2.7.7</version>
 				<executions>
 			        <execution>
 						<id>build-info</id>
@@ -505,7 +505,7 @@
 			<plugin>
             	<groupId>org.springframework.boot</groupId>
             	<artifactId>spring-boot-maven-plugin</artifactId>
-            	<version>2.7.6</version>
+            	<version>2.7.7</version>
             	<configuration>
             	    <mainClass>giis.demo.descuento.DescuentoApplication</mainClass>
             	    <classifier>deploy</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 		<dependency>
 		    <groupId>com.thoughtworks.xstream</groupId>
 		    <artifactId>xstream</artifactId>
-		    <version>1.4.19</version>
+		    <version>1.4.20</version>
 		</dependency>
 		
 		<!-- lombok, para generar automaticamente getters y setters -->

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.0.0</version>
+			<version>3.0.1</version>
     		<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.6</version>
+		<version>2.7.7</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.6.2 to 3.7.0](https://github.com/javiertuya/samples-test-spring/pull/100)
- [Bump xstream from 1.4.19 to 1.4.20](https://github.com/javiertuya/samples-test-spring/pull/104)
- [Bump selema from 3.0.0 to 3.0.1](https://github.com/javiertuya/samples-test-spring/pull/101)
- [Bump spring-boot-maven-plugin from 2.7.6 to 2.7.7](https://github.com/javiertuya/samples-test-spring/pull/103)
- [Bump spring-boot-starter-parent from 2.7.6 to 2.7.7](https://github.com/javiertuya/samples-test-spring/pull/102)