### PR TITLE
Combined dependency updates (2023-01-26)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v3
       - name: Select Java Version
         uses: actions/setup-java@v3
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-            	<version>2.7.7</version>
+            	<version>2.7.8</version>
 				<executions>
 			        <execution>
 						<id>build-info</id>
@@ -505,7 +505,7 @@
 			<plugin>
             	<groupId>org.springframework.boot</groupId>
             	<artifactId>spring-boot-maven-plugin</artifactId>
-            	<version>2.7.7</version>
+            	<version>2.7.8</version>
             	<configuration>
             	    <mainClass>giis.demo.descuento.DescuentoApplication</mainClass>
             	    <classifier>deploy</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.7</version>
+		<version>2.7.8</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.7.2</selenium.version>
+		<selenium.version>4.8.0</selenium.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/configure-pages from 2 to 3](https://github.com/javiertuya/samples-test-spring/pull/110)
- [Bump selenium-java from 4.7.2 to 4.8.0](https://github.com/javiertuya/samples-test-spring/pull/113)
- [Bump spring-boot-maven-plugin from 2.7.7 to 2.7.8](https://github.com/javiertuya/samples-test-spring/pull/111)
- [Bump spring-boot-starter-parent from 2.7.7 to 2.7.8](https://github.com/javiertuya/samples-test-spring/pull/112)