### PR TITLE
Combined dependency updates (2023-02-18)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,7 +314,7 @@ jobs:
       - name: Build executable jar
         run: mvn package  -DskipTests=true && cp target/*-deploy.jar target/samples-test-spring-latest-deploy.jar
       - name: Deploy to ${{ env.APP_NAME }}
-        uses: akhileshns/heroku-deploy@v3.12.12
+        uses: akhileshns/heroku-deploy@v3.12.13
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: ${{ env.APP_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.1
+        uses: mikepenz/action-junit-report@v3.7.3
         with:
           check_name: test-report (ut, it)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -272,7 +272,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.1
+        uses: mikepenz/action-junit-report@v3.7.3
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -333,7 +333,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.1
+        uses: mikepenz/action-junit-report@v3.7.3
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #FROM openjdk:8-jre-slim-buster
-FROM eclipse-temurin:8-jre-alpine@sha256:1d62faf876f3ff84f131c4f9ede0974e4753666c5efc151e1456ea6f6c075e30
+FROM eclipse-temurin:8-jre-alpine@sha256:ab4064508d2b7427694f19fd82d66f4b381d36d714c955219dbe8d9ba8de0964
 #EXPOSE no se tiene en cuenta en Heroku, el puerto lo pone la aplicacion en la clase principal usando la variavble PORT
 EXPOSE 8080
 #Para Azure definir la variable WEBSITES_PORT=8080 desde el portal: Settings->Configuration

--- a/pom.xml
+++ b/pom.xml
@@ -461,7 +461,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.4.1</version>
+				<version>3.5.0</version>
 				<configuration>
 					<overview>${basedir}/src/main/java/overview.html</overview>
 					<sourcepath>${basedir}/src/main/java;${basedir}/src/test/java;${basedir}/src/it/java</sourcepath>


### PR DESCRIPTION
Includes these updates:
- [Bump eclipse-temurin from `1d62faf` to `ab40645`](https://github.com/javiertuya/samples-test-spring/pull/120)
- [Bump akhileshns/heroku-deploy from 3.12.12 to 3.12.13](https://github.com/javiertuya/samples-test-spring/pull/119)
- [Bump mikepenz/action-junit-report from 3.7.1 to 3.7.3](https://github.com/javiertuya/samples-test-spring/pull/123)
- [Bump maven-javadoc-plugin from 3.4.1 to 3.5.0](https://github.com/javiertuya/samples-test-spring/pull/122)