### PR TITLE
Combined dependency updates (2023-02-25)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.3
+        uses: mikepenz/action-junit-report@v3.7.5
         with:
           check_name: test-report (ut, it)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -272,7 +272,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.3
+        uses: mikepenz/action-junit-report@v3.7.5
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -333,7 +333,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.3
+        uses: mikepenz/action-junit-report@v3.7.5
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-            	<version>2.7.8</version>
+            	<version>2.7.9</version>
 				<executions>
 			        <execution>
 						<id>build-info</id>
@@ -505,7 +505,7 @@
 			<plugin>
             	<groupId>org.springframework.boot</groupId>
             	<artifactId>spring-boot-maven-plugin</artifactId>
-            	<version>2.7.8</version>
+            	<version>2.7.9</version>
             	<configuration>
             	    <mainClass>giis.demo.descuento.DescuentoApplication</mainClass>
             	    <classifier>deploy</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.8.0</selenium.version>
+		<selenium.version>4.8.1</selenium.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.8</version>
+		<version>2.7.9</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.7.3 to 3.7.5](https://github.com/javiertuya/samples-test-spring/pull/127)
- [Bump selenium-java from 4.8.0 to 4.8.1](https://github.com/javiertuya/samples-test-spring/pull/125)
- [Bump spring-boot-maven-plugin from 2.7.8 to 2.7.9](https://github.com/javiertuya/samples-test-spring/pull/128)
- [Bump spring-boot-starter-parent from 2.7.8 to 2.7.9](https://github.com/javiertuya/samples-test-spring/pull/129)