### PR TITLE
Combined dependency updates (2023-03-18)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -364,7 +364,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
 				<!-- ejecucion de pruebas (failsafe) -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<id>integration-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0</version>
 				<configuration>
 					<skipTests>${skipTests}</skipTests>
 					<excludes>


### PR DESCRIPTION
Includes these updates:
- [Bump maven-failsafe-plugin from 2.22.2 to 3.0.0](https://github.com/javiertuya/samples-test-spring/pull/131)
- [Bump maven-surefire-plugin from 2.22.2 to 3.0.0](https://github.com/javiertuya/samples-test-spring/pull/133)
- [Bump maven-surefire-report-plugin from 2.22.2 to 3.0.0](https://github.com/javiertuya/samples-test-spring/pull/132)