### PR TITLE
Combined dependency updates (2023-03-26)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,4 +46,4 @@ jobs:
           path: 'target/site/testapidocs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v2

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.9</version>
+		<version>2.7.10</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Includes these updates:
- [Bump actions/deploy-pages from 1 to 2](https://github.com/javiertuya/samples-test-spring/pull/135)
- [Bump spring-boot-starter-parent from 2.7.9 to 2.7.10](https://github.com/javiertuya/samples-test-spring/pull/136)