### PR TITLE
Combined dependency updates (2023-04-11)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.5
+        uses: mikepenz/action-junit-report@v3.7.6
         with:
           check_name: test-report (ut, it)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -272,7 +272,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.5
+        uses: mikepenz/action-junit-report@v3.7.6
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -333,7 +333,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.5
+        uses: mikepenz/action-junit-report@v3.7.6
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.9</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TableColumnAdjuster.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.0.1</version>
+			<version>3.0.2</version>
     		<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.8.1</selenium.version>
+		<selenium.version>4.8.3</selenium.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.7.5 to 3.7.6](https://github.com/javiertuya/samples-test-spring/pull/140)
- [Bump selema from 3.0.1 to 3.0.2](https://github.com/javiertuya/samples-test-spring/pull/141)
- [Bump jacoco-maven-plugin from 0.8.8 to 0.8.9](https://github.com/javiertuya/samples-test-spring/pull/142)
- [Bump selenium-java from 4.8.1 to 4.8.3](https://github.com/javiertuya/samples-test-spring/pull/139)