### PR TITLE
Combined dependency updates (2023-05-01)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.9</version>
+				<version>0.8.10</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TableColumnAdjuster.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.10</version>
+		<version>2.7.11</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.0.2</version>
+			<version>3.0.3</version>
     		<scope>test</scope>
 		</dependency>
 		<!-- Tras las actualizaciones de 2023-04-11 la ultima version de webdrivermanager


### PR DESCRIPTION
Includes these updates:
- [Bump selema from 3.0.2 to 3.0.3](https://github.com/javiertuya/samples-test-spring/pull/146)
- [Bump jacoco-maven-plugin from 0.8.9 to 0.8.10](https://github.com/javiertuya/samples-test-spring/pull/147)
- [Bump spring-boot-starter-parent from 2.7.10 to 2.7.11](https://github.com/javiertuya/samples-test-spring/pull/145)