### PR TITLE
Combined dependency updates (2023-06-10)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.6
+        uses: mikepenz/action-junit-report@v3.7.7
         with:
           check_name: test-report (ut, it)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -272,7 +272,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.6
+        uses: mikepenz/action-junit-report@v3.7.7
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -349,7 +349,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.6
+        uses: mikepenz/action-junit-report@v3.7.7
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.1.0</version><!--$NO-MVN-MAN-VER$-->
+				<version>3.1.2</version><!--$NO-MVN-MAN-VER$-->
 				<configuration>
 					<skipTests>${skipTests}</skipTests>
 					<excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
 				<!-- ejecucion de pruebas (failsafe) -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.1.0</version><!--$NO-MVN-MAN-VER$-->
+				<version>3.1.2</version><!--$NO-MVN-MAN-VER$-->
 				<executions>
 					<execution>
 						<id>integration-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.9.1</selenium.version>
+		<selenium.version>4.10.0</selenium.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.2</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/pom.xml
+++ b/pom.xml
@@ -454,7 +454,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>license-maven-plugin</artifactId>
-				<version>2.0.1</version>
+				<version>2.1.0</version>
 			</plugin>
 			<!-- Generacion de documentacion javadoc, incluyendo un jar -->
 			<plugin>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.7.6 to 3.7.7](https://github.com/javiertuya/samples-test-spring/pull/161)
- [Bump maven-failsafe-plugin from 3.1.0 to 3.1.2](https://github.com/javiertuya/samples-test-spring/pull/162)
- [Bump maven-surefire-plugin from 3.1.0 to 3.1.2](https://github.com/javiertuya/samples-test-spring/pull/165)
- [Bump maven-surefire-report-plugin from 3.1.0 to 3.1.2](https://github.com/javiertuya/samples-test-spring/pull/164)
- [Bump license-maven-plugin from 2.0.1 to 2.1.0](https://github.com/javiertuya/samples-test-spring/pull/163)
- [Bump selenium-java from 4.9.1 to 4.10.0](https://github.com/javiertuya/samples-test-spring/pull/166)