### PR TITLE
Combined dependency updates (2023-07-22)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.0.0
+      - uses: javiertuya/sonarqube-action@v1.1.0
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.8
+        uses: mikepenz/action-junit-report@v3.8.0
         with:
           check_name: test-report (ut, it)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -222,7 +222,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.8
+        uses: mikepenz/action-junit-report@v3.8.0
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -299,7 +299,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.8
+        uses: mikepenz/action-junit-report@v3.8.0
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build javadoc
         run: mvn install -DskipTests=true -DskipITs=true -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2.0.0
         with:
           path: 'target/site/testapidocs'
       - name: Deploy to GitHub Pages

--- a/pom.xml
+++ b/pom.xml
@@ -453,11 +453,6 @@
 					</dependency>
 				</dependencies>
 			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>license-maven-plugin</artifactId>
-				<version>2.1.0</version>
-			</plugin>
 			<!-- Generacion de documentacion javadoc, incluyendo un jar -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.13</version>
+		<version>2.7.14</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Includes these updates:
- [Bump actions/upload-pages-artifact from 1 to 2](https://github.com/javiertuya/samples-test-spring/pull/173)
- [Bump javiertuya/sonarqube-action from 1.0.0 to 1.1.0](https://github.com/javiertuya/samples-test-spring/pull/171)
- [Bump mikepenz/action-junit-report from 3.7.8 to 3.8.0](https://github.com/javiertuya/samples-test-spring/pull/174)
- [Bump license-maven-plugin from 2.1.0 to 2.2.0](https://github.com/javiertuya/samples-test-spring/pull/172)
- [Bump org.springframework.boot:spring-boot-starter-parent from 2.7.13 to 2.7.14](https://github.com/javiertuya/samples-test-spring/pull/175)