### PR TITLE
Combined dependency updates (2023-08-02)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.1.0
+      - uses: javiertuya/sonarqube-action@v1.1.1
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.0.3</version>
+			<version>3.0.4</version>
     		<scope>test</scope>
 		</dependency>
 		<!-- Tras las actualizaciones de 2023-04-11 la ultima version de webdrivermanager

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.10.0</selenium.version>
+		<selenium.version>4.11.0</selenium.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Includes these updates:
- [Bump javiertuya/sonarqube-action from 1.1.0 to 1.1.1](https://github.com/javiertuya/samples-test-spring/pull/178)
- [Bump io.github.javiertuya:selema from 3.0.3 to 3.0.4](https://github.com/javiertuya/samples-test-spring/pull/177)
- [Bump org.seleniumhq.selenium:selenium-java from 4.10.0 to 4.11.0](https://github.com/javiertuya/samples-test-spring/pull/179)