### PR TITLE
Combined dependency updates (2023-08-26)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.14</version>
+		<version>2.7.15</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant-junit</artifactId>
-						<version>1.10.13</version>
+						<version>1.10.14</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.ant</groupId>


### PR DESCRIPTION
Includes these updates:
- [Bump org.apache.ant:ant-junit from 1.10.13 to 1.10.14](https://github.com/javiertuya/samples-test-spring/pull/182)
- [Bump org.springframework.boot:spring-boot-starter-parent from 2.7.14 to 2.7.15](https://github.com/javiertuya/samples-test-spring/pull/183)