### PR TITLE
Combined dependency updates (2023-10-20)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #Note that dependabot does not trigger PR if a previous closed PR exists
 #even there is a new image with a different SHA.
 #Do not use combined updates for docker dependencies
-FROM eclipse-temurin:17-jre-alpine@sha256:642f8b0eee66d8d2fbe07028dd511a2e531a85bd190986a3fad571032371e026
+FROM eclipse-temurin:17-jre-alpine@sha256:532dc48a91112108f012784618213767e7458368b51b77d37a1a076cd7e70ef8
 
 #EXPOSE no se tiene en cuenta en Heroku, el puerto lo pone la aplicacion en la clase principal usando la variavble PORT
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.10</version>
+				<version>0.8.11</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TableColumnAdjuster.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.4</version>
+		<version>3.1.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Includes these updates:
- [Bump eclipse-temurin from `642f8b0` to `532dc48`](https://github.com/javiertuya/samples-test-spring/pull/205)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.10 to 0.8.11](https://github.com/javiertuya/samples-test-spring/pull/202)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.1.4 to 3.1.5](https://github.com/javiertuya/samples-test-spring/pull/204)