### PR TITLE
Combined dependency updates (2023-11-04)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.1
+        uses: mikepenz/action-junit-report@v4.0.3
         with:
           check_name: test-report (ut, it)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -235,7 +235,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.1
+        uses: mikepenz/action-junit-report@v4.0.3
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -312,7 +312,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.1
+        uses: mikepenz/action-junit-report@v4.0.3
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.14.1</selenium.version>
+		<selenium.version>4.15.0</selenium.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
 		
-		<surefire.version>3.1.2</surefire.version>
+		<surefire.version>3.2.1</surefire.version>
 		<!-- removes error flag that appears for some eclipse users -->
 		<maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
 		<!-- required for sonarcloud.io -->


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 4.0.1 to 4.0.3](https://github.com/javiertuya/samples-test-spring/pull/207)
- [Bump org.seleniumhq.selenium:selenium-java from 4.14.1 to 4.15.0](https://github.com/javiertuya/samples-test-spring/pull/209)
- [Bump surefire.version from 3.1.2 to 3.2.1](https://github.com/javiertuya/samples-test-spring/pull/208)