### PR TITLE
Combined dependency updates (2023-11-26)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.5</version>
+		<version>3.2.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
 		
-		<surefire.version>3.2.1</surefire.version>
+		<surefire.version>3.2.2</surefire.version>
 		<!-- removes error flag that appears for some eclipse users -->
 		<maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
 		<!-- required for sonarcloud.io -->


### PR DESCRIPTION
Includes these updates:
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.1.5 to 3.2.0](https://github.com/javiertuya/samples-test-spring/pull/212)
- [Bump surefire.version from 3.2.1 to 3.2.2](https://github.com/javiertuya/samples-test-spring/pull/211)