### PR TITLE
Combined dependency updates (2023-12-08)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       #Especifica java 17, requerido por Spring Boot 3
       - name: Select Java Version
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -100,7 +100,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Select Java Version
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -163,7 +163,7 @@ jobs:
       - run: echo "Deploying to '${{ env.APP_NAME }}'"
 
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -284,7 +284,7 @@ jobs:
       - run: echo "Deploying to '${{ env.APP_NAME }}'"
 
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.1.1
+      - uses: javiertuya/sonarqube-action@v1.1.2
         with: 
           java-version: 17
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Select Java Version
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Select Java Version
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,4 +46,4 @@ jobs:
           path: 'target/site/testapidocs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.1.1</version>
+			<version>3.2.0</version>
     		<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.15.0</selenium.version>
+		<selenium.version>4.16.1</selenium.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/configure-pages from 3 to 4](https://github.com/javiertuya/samples-test-spring/pull/216)
- [Bump actions/deploy-pages from 2 to 3](https://github.com/javiertuya/samples-test-spring/pull/218)
- [Bump actions/setup-java from 3 to 4](https://github.com/javiertuya/samples-test-spring/pull/214)
- [Bump javiertuya/sonarqube-action from 1.1.1 to 1.1.2](https://github.com/javiertuya/samples-test-spring/pull/217)
- [Bump io.github.javiertuya:selema from 3.1.1 to 3.2.0](https://github.com/javiertuya/samples-test-spring/pull/219)
- [Bump org.seleniumhq.selenium:selenium-java from 4.15.0 to 4.16.1](https://github.com/javiertuya/samples-test-spring/pull/220)