### PR TITLE
Combined dependency updates (2023-12-24)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         run: mv ./target/site/video/video-*.mp4 ./target/selema/
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports
           path: |
@@ -85,7 +85,7 @@ jobs:
             !target/site/video/slenoid*.mp4
       - if: always()
         name: Publish test reports for sonarqube job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports-for-sonar
           path: |
@@ -122,7 +122,7 @@ jobs:
 
       - if: always()
         name: Publish reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dependency-check-reports
           path: reports/
@@ -244,7 +244,7 @@ jobs:
       #Publica archivos de reports
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: deploy-test-reports
           path: |
@@ -321,7 +321,7 @@ jobs:
       #Publica archivos de reports
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: deploy-test-reports
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.1.2
+      - uses: javiertuya/sonarqube-action@v1.2.0
         with: 
           java-version: 17
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,4 +46,4 @@ jobs:
           path: 'target/site/testapidocs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build javadoc
         run: mvn install -DskipTests=true -DskipITs=true -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2.0.0
+        uses: actions/upload-pages-artifact@v3.0.0
         with:
           path: 'target/site/testapidocs'
       - name: Deploy to GitHub Pages

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.0</version>
+		<version>3.2.1</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
 		
-		<surefire.version>3.2.2</surefire.version>
+		<surefire.version>3.2.3</surefire.version>
 		<!-- removes error flag that appears for some eclipse users -->
 		<maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
 		<!-- required for sonarcloud.io -->


### PR DESCRIPTION
Includes these updates:
- [Bump actions/deploy-pages from 3 to 4](https://github.com/javiertuya/samples-test-spring/pull/225)
- [Bump actions/upload-artifact from 3 to 4](https://github.com/javiertuya/samples-test-spring/pull/222)
- [Bump actions/upload-pages-artifact from 2.0.0 to 3.0.0](https://github.com/javiertuya/samples-test-spring/pull/224)
- [Bump javiertuya/sonarqube-action from 1.1.2 to 1.2.0](https://github.com/javiertuya/samples-test-spring/pull/226)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.2.0 to 3.2.1](https://github.com/javiertuya/samples-test-spring/pull/227)
- [Bump surefire.version from 3.2.2 to 3.2.3](https://github.com/javiertuya/samples-test-spring/pull/223)