### PR TITLE
Combined dependency updates (2024-01-27)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,9 +137,8 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.2.0
+      - uses: javiertuya/sonarqube-action@v1.3.0
         with: 
-          java-version: 17
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           restore-artifact-name1: "test-reports-for-sonar"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.3
+        uses: mikepenz/action-junit-report@v4.0.4
         with:
           check_name: test-report (ut, it)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -235,7 +235,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.3
+        uses: mikepenz/action-junit-report@v4.0.4
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -312,7 +312,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.3
+        uses: mikepenz/action-junit-report@v4.0.4
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,7 +293,7 @@ jobs:
       - name: Build executable jar
         run: mvn package  -DskipTests=true && cp target/*.jar target/samples-test-spring-latest-deploy.jar
       - name: Deploy to ${{ env.APP_NAME }}
-        uses: akhileshns/heroku-deploy@v3.12.14
+        uses: akhileshns/heroku-deploy@v3.13.15
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: ${{ env.APP_NAME }}

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.1</version>
+		<version>3.2.2</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.16.1</selenium.version>
+		<selenium.version>4.17.0</selenium.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
 		
-		<surefire.version>3.2.3</surefire.version>
+		<surefire.version>3.2.5</surefire.version>
 		<!-- removes error flag that appears for some eclipse users -->
 		<maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
 		<!-- required for sonarcloud.io -->


### PR DESCRIPTION
Includes these updates:
- [Update sonarqube-action to v1.3.0](https://github.com/javiertuya/samples-test-spring/pull/235/commits/45672dfde106f28bb9ce0d69f18dfa6662624988)
- [Bump akhileshns/heroku-deploy from 3.12.14 to 3.13.15](https://github.com/javiertuya/samples-test-spring/pull/229)
- [Bump mikepenz/action-junit-report from 4.0.3 to 4.0.4](https://github.com/javiertuya/samples-test-spring/pull/231)
- [Bump org.seleniumhq.selenium:selenium-java from 4.16.1 to 4.17.0](https://github.com/javiertuya/samples-test-spring/pull/233)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.2.1 to 3.2.2](https://github.com/javiertuya/samples-test-spring/pull/232)
- [Bump surefire.version from 3.2.3 to 3.2.5](https://github.com/javiertuya/samples-test-spring/pull/230)