### PR TITLE
Combined dependency updates (2024-04-06)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
       - name: Select Java Version
         uses: actions/setup-java@v4
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.11</version>
+				<version>0.8.12</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TableColumnAdjuster.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.19.0</selenium.version>
+		<selenium.version>4.19.1</selenium.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/configure-pages from 4 to 5](https://github.com/javiertuya/samples-test-spring/pull/255)
- [Bump org.seleniumhq.selenium:selenium-java from 4.19.0 to 4.19.1](https://github.com/javiertuya/samples-test-spring/pull/254)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.11 to 0.8.12](https://github.com/javiertuya/samples-test-spring/pull/253)