### PR TITLE
Combined dependency updates (2024-04-27)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,7 +292,7 @@ jobs:
       - name: Build executable jar
         run: mvn package  -DskipTests=true && cp target/*.jar target/samples-test-spring-latest-deploy.jar
       - name: Deploy to ${{ env.APP_NAME }}
-        uses: akhileshns/heroku-deploy@v3.13.15
+        uses: akhileshns/heroku-deploy@v4
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: ${{ env.APP_NAME }}

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.2.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.19.1</selenium.version>
+		<selenium.version>4.20.0</selenium.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.seleniumhq.selenium:selenium-java from 4.19.1 to 4.20.0](https://github.com/javiertuya/samples-test-spring/pull/260)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.2.4 to 3.2.5](https://github.com/javiertuya/samples-test-spring/pull/258)
- [Bump akhileshns/heroku-deploy from 3.13.15 to 4](https://github.com/javiertuya/samples-test-spring/pull/257)