### PR TITLE
Combined dependency updates (2024-05-25)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
     		<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.5</version>
+		<version>3.2.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.20.0</selenium.version>
+		<selenium.version>4.21.0</selenium.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.2.5 to 3.2.6](https://github.com/javiertuya/samples-test-spring/pull/267)
- [Bump org.seleniumhq.selenium:selenium-java from 4.20.0 to 4.21.0](https://github.com/javiertuya/samples-test-spring/pull/264)
- [Bump io.github.javiertuya:selema from 3.2.1 to 3.2.2](https://github.com/javiertuya/samples-test-spring/pull/263)