### PR TITLE
Combined dependency updates (2024-07-20)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.3.2
+      - uses: javiertuya/sonarqube-action@v1.4.0
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
 		
-		<surefire.version>3.3.0</surefire.version>
+		<surefire.version>3.3.1</surefire.version>
 		<!-- removes error flag that appears for some eclipse users -->
 		<maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
 		<!-- required for sonarcloud.io -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.7</version>
+		<version>3.2.8</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.2.7 to 3.2.8](https://github.com/javiertuya/samples-test-spring/pull/283)
- [Bump javiertuya/sonarqube-action from 1.3.2 to 1.4.0](https://github.com/javiertuya/samples-test-spring/pull/282)
- [Bump surefire.version from 3.3.0 to 3.3.1](https://github.com/javiertuya/samples-test-spring/pull/281)