### PR TITLE
Combined dependency updates (2024-09-02)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.8</version>
+		<version>3.2.9</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
 		
-		<surefire.version>3.3.1</surefire.version>
+		<surefire.version>3.5.0</surefire.version>
 		<!-- removes error flag that appears for some eclipse users -->
 		<maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
 		<!-- required for sonarcloud.io -->

--- a/pom.xml
+++ b/pom.xml
@@ -426,7 +426,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant-junit</artifactId>
-						<version>1.10.14</version>
+						<version>1.10.15</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.ant</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.22.0</selenium.version>
+		<selenium.version>4.24.0</selenium.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.ant:ant-junit from 1.10.14 to 1.10.15](https://github.com/javiertuya/samples-test-spring/pull/291)
- [Bump surefire.version from 3.3.1 to 3.5.0](https://github.com/javiertuya/samples-test-spring/pull/290)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.2.8 to 3.2.9](https://github.com/javiertuya/samples-test-spring/pull/289)
- [Bump org.seleniumhq.selenium:selenium-java from 4.22.0 to 4.24.0](https://github.com/javiertuya/samples-test-spring/pull/288)