### PR TITLE
Combined dependency updates (2024-10-02)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #Note that dependabot does not trigger PR if a previous closed PR exists
 #even there is a new image with a different SHA.
 #Do not use combined updates for docker dependencies
-FROM eclipse-temurin:17-jre-alpine@sha256:68b6af70562c648a9d871d866849eb1b82e13152e09503fc9f62bf8bf8ab2fe7
+FROM eclipse-temurin:17-jre-alpine@sha256:31c3cc1b2b02ae43a3af8a34b0d4a20208818355b68f3112933f9e8fa5be9a3b
 
 #EXPOSE no se tiene en cuenta en Heroku, el puerto lo pone la aplicacion en la clase principal usando la variavble PORT
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.9</version>
+		<version>3.3.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.24.0</selenium.version>
+		<selenium.version>4.25.0</selenium.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump eclipse-temurin from `68b6af7` to `31c3cc1`](https://github.com/javiertuya/samples-test-spring/pull/295)
- [Bump org.seleniumhq.selenium:selenium-java from 4.24.0 to 4.25.0](https://github.com/javiertuya/samples-test-spring/pull/294)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.2.9 to 3.3.4](https://github.com/javiertuya/samples-test-spring/pull/293)