### PR TITLE
Combined dependency updates (2024-11-02)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.25.0</selenium.version>
+		<selenium.version>4.26.0</selenium.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
 		
-		<surefire.version>3.5.0</surefire.version>
+		<surefire.version>3.5.1</surefire.version>
 		<!-- removes error flag that appears for some eclipse users -->
 		<maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
 		<!-- required for sonarcloud.io -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.4</version>
+		<version>3.3.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump surefire.version from 3.5.0 to 3.5.1](https://github.com/javiertuya/samples-test-spring/pull/299)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.3.4 to 3.3.5](https://github.com/javiertuya/samples-test-spring/pull/298)
- [Bump org.seleniumhq.selenium:selenium-java from 4.25.0 to 4.26.0](https://github.com/javiertuya/samples-test-spring/pull/297)