### PR TITLE
Combined dependency updates (2025-02-03)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.2.0
+        uses: mikepenz/action-junit-report@v5.3.0
         with:
           check_name: test-report
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -244,7 +244,7 @@ jobs:
         run: mvn test -Dtest=**/st/** -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.2.0
+        uses: mikepenz/action-junit-report@v5.3.0
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -322,7 +322,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.2.0
+        uses: mikepenz/action-junit-report@v5.3.0
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.2.3</version>
+			<version>3.3.0</version>
     		<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
-			<version>1.9.4</version>
+			<version>1.10.0</version>
 		</dependency>
 		
 		<!-- Selenium bindings -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.1</version>
+		<version>3.4.2</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.27.0</selenium.version>
+		<selenium.version>4.28.1</selenium.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.4.1 to 3.4.2](https://github.com/javiertuya/samples-test-spring/pull/315)
- [Bump io.github.javiertuya:selema from 3.2.3 to 3.3.0](https://github.com/javiertuya/samples-test-spring/pull/314)
- [Bump org.seleniumhq.selenium:selenium-java from 4.27.0 to 4.28.1](https://github.com/javiertuya/samples-test-spring/pull/313)
- [Bump commons-beanutils:commons-beanutils from 1.9.4 to 1.10.0](https://github.com/javiertuya/samples-test-spring/pull/312)
- [Bump mikepenz/action-junit-report from 5.2.0 to 5.3.0](https://github.com/javiertuya/samples-test-spring/pull/311)