### PR TITLE
Combined dependency updates (2025-04-02)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.4.0
+        uses: mikepenz/action-junit-report@v5.5.1
         with:
           check_name: test-report
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -244,7 +244,7 @@ jobs:
         run: mvn test -Dtest=**/st/** -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.4.0
+        uses: mikepenz/action-junit-report@v5.5.1
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -322,7 +322,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.4.0
+        uses: mikepenz/action-junit-report@v5.5.1
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.29.0</selenium.version>
+		<selenium.version>4.30.0</selenium.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.3.0</version>
+			<version>3.4.0</version>
     		<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
 		
-		<surefire.version>3.5.2</surefire.version>
+		<surefire.version>3.5.3</surefire.version>
 		<!-- removes error flag that appears for some eclipse users -->
 		<maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
 		<!-- required for sonarcloud.io -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.3</version>
+		<version>3.4.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.4.3 to 3.4.4](https://github.com/javiertuya/samples-test-spring/pull/326)
- [Bump io.github.javiertuya:selema from 3.3.0 to 3.4.0](https://github.com/javiertuya/samples-test-spring/pull/325)
- [Bump surefire.version from 3.5.2 to 3.5.3](https://github.com/javiertuya/samples-test-spring/pull/324)
- [Bump org.seleniumhq.selenium:selenium-java from 4.29.0 to 4.30.0](https://github.com/javiertuya/samples-test-spring/pull/323)
- [Bump mikepenz/action-junit-report from 5.4.0 to 5.5.1](https://github.com/javiertuya/samples-test-spring/pull/322)