### PR TITLE
Combined dependency updates (2025-05-03)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.4.1
+      - uses: javiertuya/sonarqube-action@v1.4.2
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.12</version>
+				<version>0.8.13</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TableColumnAdjuster.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.30.0</selenium.version>
+		<selenium.version>4.31.0</selenium.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.4</version>
+		<version>3.4.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
 		<dependency>
 			<groupId>org.jsmart</groupId>
 			<artifactId>zerocode-tdd</artifactId>
-			<version>1.3.44</version>
+			<version>1.3.45</version>
     		<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump javiertuya/sonarqube-action from 1.4.1 to 1.4.2](https://github.com/javiertuya/samples-test-spring/pull/332)
- [Bump org.seleniumhq.selenium:selenium-java from 4.30.0 to 4.31.0](https://github.com/javiertuya/samples-test-spring/pull/331)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.4.4 to 3.4.5](https://github.com/javiertuya/samples-test-spring/pull/330)
- [Bump org.jsmart:zerocode-tdd from 1.3.44 to 1.3.45](https://github.com/javiertuya/samples-test-spring/pull/329)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.12 to 0.8.13](https://github.com/javiertuya/samples-test-spring/pull/328)