### PR TITLE
Combined dependency updates (2025-06-07)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.5.1
+        uses: mikepenz/action-junit-report@v5.6.0
         with:
           check_name: test-report
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -244,7 +244,7 @@ jobs:
         run: mvn test -Dtest=**/st/** -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.5.1
+        uses: mikepenz/action-junit-report@v5.6.0
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -322,7 +322,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.5.1
+        uses: mikepenz/action-junit-report@v5.6.0
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
+		<version>3.5.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.4.0</version>
+			<version>3.4.1</version>
     		<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
-			<version>1.10.1</version>
+			<version>1.11.0</version>
 		</dependency>
 		
 		<!-- Selenium bindings -->

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.31.0</selenium.version>
+		<selenium.version>4.33.0</selenium.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mikepenz/action-junit-report from 5.5.1 to 5.6.0](https://github.com/javiertuya/samples-test-spring/pull/338)
- [Bump org.seleniumhq.selenium:selenium-java from 4.31.0 to 4.33.0](https://github.com/javiertuya/samples-test-spring/pull/337)
- [Bump io.github.javiertuya:selema from 3.4.0 to 3.4.1](https://github.com/javiertuya/samples-test-spring/pull/336)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.4.5 to 3.5.0](https://github.com/javiertuya/samples-test-spring/pull/335)
- [Bump commons-beanutils:commons-beanutils from 1.10.1 to 1.11.0](https://github.com/javiertuya/samples-test-spring/pull/334)