### PR TITLE
Combined dependency updates (2025-09-02)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     #if: ${{ false }}  # disable for now
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       #Especifica java 17, requerido por Spring Boot 3
       - name: Select Java Version
         uses: actions/setup-java@v4
@@ -101,7 +101,7 @@ jobs:
     if: ${{ false }}  # disable for now (analysis hangs, failing after timeout, July 2025)
     #if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Select Java Version
         uses: actions/setup-java@v4
         with:
@@ -166,7 +166,7 @@ jobs:
         run: echo "APP_NAME=samples-test-spring-develop" >> $GITHUB_ENV
       - run: echo "Deploying to '${{ env.APP_NAME }}'"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Select Java Version
         uses: actions/setup-java@v4
         with:
@@ -296,7 +296,7 @@ jobs:
         run: echo "APP_NAME=samples-test-spring-develop" >> $GITHUB_ENV
       - run: echo "Deploying to '${{ env.APP_NAME }}'"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Select Java Version
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
       #Especifica java 17, requerido por Spring Boot 3
       - name: Select Java Version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Select Java Version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -168,7 +168,7 @@ jobs:
 
       - uses: actions/checkout@v4
       - name: Select Java Version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -298,7 +298,7 @@ jobs:
 
       - uses: actions/checkout@v4
       - name: Select Java Version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Select Java Version

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,7 +42,7 @@ jobs:
         run: mvn package -DskipTests=true -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - run: ls -la target/reports
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3.0.1
+        uses: actions/upload-pages-artifact@v4.0.0
         with:
           path: 'target/reports/testapidocs'
       - name: Deploy to GitHub Pages

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Select Java Version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Select Java Version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       packages: write 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Select Java Version
         uses: actions/setup-java@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #Do not use combined updates for docker dependencies
 #FROM eclipse-temurin:17-jre-alpine@sha256:fcf70ae7ba37872c7d1da875593321c3e90bd9a02c6b4bfde5a1260b08b8f178
 #Fixes version to allow combined updates
-FROM eclipse-temurin:17.0.15_6-jre-alpine
+FROM eclipse-temurin:17.0.16_8-jre-alpine
 
 #EXPOSE no se tiene en cuenta en Heroku, el puerto lo pone la aplicacion en la clase principal usando la variavble PORT
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.34.0</selenium.version>
+		<selenium.version>4.35.0</selenium.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/checkout from 4 to 5](https://github.com/javiertuya/samples-test-spring/pull/353)
- [Bump actions/setup-java from 4 to 5](https://github.com/javiertuya/samples-test-spring/pull/351)
- [Bump actions/upload-pages-artifact from 3.0.1 to 4.0.0](https://github.com/javiertuya/samples-test-spring/pull/352)
- [Bump eclipse-temurin from 17.0.15_6-jre-alpine to 17.0.16_8-jre-alpine](https://github.com/javiertuya/samples-test-spring/pull/354)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.5.4 to 3.5.5](https://github.com/javiertuya/samples-test-spring/pull/350)
- [Bump org.seleniumhq.selenium:selenium-java from 4.34.0 to 4.35.0](https://github.com/javiertuya/samples-test-spring/pull/349)