### PR TITLE
Combined dependency updates (2025-11-02)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.6.2
+        uses: mikepenz/action-junit-report@v6.0.0
         with:
           check_name: test-report
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -247,7 +247,7 @@ jobs:
         run: mvn test -Dtest=**/st/** -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.6.2
+        uses: mikepenz/action-junit-report@v6.0.0
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -326,7 +326,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v5.6.2
+        uses: mikepenz/action-junit-report@v6.0.0
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         run: mv ./target/site/video/video-*.mp4 ./target/selema/
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-reports
           path: |
@@ -88,7 +88,7 @@ jobs:
             !target/site/video/
       - if: always()
         name: Publish test reports for sonarqube job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-reports-for-sonar
           path: |
@@ -125,7 +125,7 @@ jobs:
 
       - if: always()
         name: Publish reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dependency-check-reports
           path: reports/
@@ -256,7 +256,7 @@ jobs:
       #Publica archivos de reports
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: deploy-test-reports
           path: |
@@ -335,7 +335,7 @@ jobs:
       #Publica archivos de reports
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: deploy-test-reports
           path: |

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.7</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.13</version>
+				<version>0.8.14</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TableColumnAdjuster.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.35.0</selenium.version>
+		<selenium.version>4.38.0</selenium.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>3.4.1</version>
+			<version>4.0.0</version>
     		<scope>test</scope>
 		</dependency>
 

--- a/src/test/java/giis/demo/descuento/it/TestDescuentoSelema.java
+++ b/src/test/java/giis/demo/descuento/it/TestDescuentoSelema.java
@@ -20,7 +20,7 @@ import giis.demo.util.*;
 import giis.selema.framework.junit4.LifecycleJunit4Test;
 import giis.selema.manager.SelemaConfig;
 import giis.selema.manager.SeleManager;
-import giis.selema.services.impl.SelenoidService;
+import giis.selema.services.browser.SelenoidBrowserService;
 import giis.selema.services.impl.WatermarkService;
 
 /**
@@ -40,7 +40,7 @@ public class TestDescuentoSelema {
 		sm=new SeleManager(new SelemaConfig().setReportSubdir("target/selema")) //carpeta especifica para estos reports
 			.setBrowser("chrome")
 			.setDriverUrl(SeleniumUtil.getRemoteWebDriverUrl()) //leido del archivo properties (si existe), si es "" indicara driver local
-			.add(new SelenoidService().setVideo()) //configura para uso de selenoid con grabacion de video
+			.add(new SelenoidBrowserService().setVideo()) //configura para uso de selenoid con grabacion de video
 			.add(new WatermarkService().setDelayOnFailure(3)); //insercion de marcas de agua en la pagina bajo test, si falla espera 3 segundos para poder observar el estado
 	@Rule public LifecycleJunit4Test tw = new LifecycleJunit4Test(sm);
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump io.github.javiertuya:selema from 3.4.1 to 4.0.0](https://github.com/javiertuya/samples-test-spring/pull/363)
- [Bump org.seleniumhq.selenium:selenium-java from 4.35.0 to 4.38.0](https://github.com/javiertuya/samples-test-spring/pull/364)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.13 to 0.8.14](https://github.com/javiertuya/samples-test-spring/pull/362)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.5.6 to 3.5.7](https://github.com/javiertuya/samples-test-spring/pull/361)
- [Bump mikepenz/action-junit-report from 5.6.2 to 6.0.0](https://github.com/javiertuya/samples-test-spring/pull/360)
- [Bump actions/upload-artifact from 4 to 5](https://github.com/javiertuya/samples-test-spring/pull/359)