### PR TITLE
Combined dependency updates (2025-12-02)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     #if: ${{ false }}  # disable for now
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       #Especifica java 17, requerido por Spring Boot 3
       - name: Select Java Version
         uses: actions/setup-java@v5
@@ -101,7 +101,7 @@ jobs:
     if: ${{ false }}  # disable for now (analysis hangs, failing after timeout, July 2025)
     #if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:
@@ -166,7 +166,7 @@ jobs:
         run: echo "APP_NAME=samples-test-spring-develop" >> $GITHUB_ENV
       - run: echo "Deploying to '${{ env.APP_NAME }}'"
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:
@@ -296,7 +296,7 @@ jobs:
         run: echo "APP_NAME=samples-test-spring-develop" >> $GITHUB_ENV
       - run: echo "Deploying to '${{ env.APP_NAME }}'"
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.0.0
+        uses: mikepenz/action-junit-report@v6.0.1
         with:
           check_name: test-report
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -247,7 +247,7 @@ jobs:
         run: mvn test -Dtest=**/st/** -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.0.0
+        uses: mikepenz/action-junit-report@v6.0.1
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -326,7 +326,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.0.0
+        uses: mikepenz/action-junit-report@v6.0.1
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Select Java Version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       packages: write 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #Do not use combined updates for docker dependencies
 #FROM eclipse-temurin:17-jre-alpine@sha256:fcf70ae7ba37872c7d1da875593321c3e90bd9a02c6b4bfde5a1260b08b8f178
 #Fixes version to allow combined updates
-FROM eclipse-temurin:17.0.16_8-jre-alpine
+FROM eclipse-temurin:17.0.17_10-jre-alpine
 
 #EXPOSE no se tiene en cuenta en Heroku, el puerto lo pone la aplicacion en la clase principal usando la variavble PORT
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>4.0.0</version>
+			<version>4.0.1</version>
     		<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/checkout from 5 to 6](https://github.com/javiertuya/samples-test-spring/pull/370)
- [Bump mikepenz/action-junit-report from 6.0.0 to 6.0.1](https://github.com/javiertuya/samples-test-spring/pull/369)
- [Bump eclipse-temurin from 17.0.16_8-jre-alpine to 17.0.17_10-jre-alpine](https://github.com/javiertuya/samples-test-spring/pull/368)
- [Bump io.github.javiertuya:selema from 4.0.0 to 4.0.1](https://github.com/javiertuya/samples-test-spring/pull/366)