### PR TITLE
Combined dependency updates (2026-03-02)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
         run: cp -r ./target/assets/* ./target/selema/
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports
           path: |
@@ -85,7 +85,7 @@ jobs:
             target/selema/
       - if: always()
         name: Publish test reports for sonarqube job
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports-for-sonar
           path: |
@@ -122,7 +122,7 @@ jobs:
 
       - if: always()
         name: Publish reports
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dependency-check-reports
           path: reports/
@@ -254,7 +254,7 @@ jobs:
       #Publica archivos de reports
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: deploy-test-reports
           path: |
@@ -324,7 +324,7 @@ jobs:
       #Publica archivos de reports
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: deploy-test-reports
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.2.0
+        uses: mikepenz/action-junit-report@v6.3.0
         with:
           check_name: test-report
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -245,7 +245,7 @@ jobs:
         run: mvn test -Dtest=**/st/** -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.2.0
+        uses: mikepenz/action-junit-report@v6.3.0
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -315,7 +315,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.2.0
+        uses: mikepenz/action-junit-report@v6.3.0
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.2</version>
+		<version>4.0.3</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
 		
-		<surefire.version>3.5.4</surefire.version>
+		<surefire.version>3.5.5</surefire.version>
 		<!-- removes error flag that appears for some eclipse users -->
 		<maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
 		<!-- required for sonarcloud.io -->

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.40.0</selenium.version>
+		<selenium.version>4.41.0</selenium.version>
 		
 		<!-- A partir de la 7.20 ha habido muchos problemas para ejecutar con junit 5
 		que impiden descubrir los features, parece que usando 7.19 no aparecen,

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<!-- A partir de la 7.20 ha habido muchos problemas para ejecutar con junit 5
 		que impiden descubrir los features, parece que usando 7.19 no aparecen,
 		pero de momento se ejecutara cucumber bajo junit 4 -->
-		<cucumber.version>7.33.0</cucumber.version>
+		<cucumber.version>7.34.2</cucumber.version>
 
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
 		<dependency>
 			<groupId>org.jsmart</groupId>
 			<artifactId>zerocode-tdd</artifactId>
-			<version>1.3.45</version>
+			<version>1.3.47</version>
     		<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.jsmart:zerocode-tdd from 1.3.45 to 1.3.47](https://github.com/javiertuya/samples-test-spring/pull/389)
- [Bump org.seleniumhq.selenium:selenium-java from 4.40.0 to 4.41.0](https://github.com/javiertuya/samples-test-spring/pull/388)
- [Bump org.springframework.boot:spring-boot-starter-parent from 4.0.2 to 4.0.3](https://github.com/javiertuya/samples-test-spring/pull/387)
- [Bump surefire.version from 3.5.4 to 3.5.5](https://github.com/javiertuya/samples-test-spring/pull/386)
- [Bump cucumber.version from 7.33.0 to 7.34.2](https://github.com/javiertuya/samples-test-spring/pull/385)
- [Bump mikepenz/action-junit-report from 6.2.0 to 6.3.0](https://github.com/javiertuya/samples-test-spring/pull/384)
- [Bump actions/upload-artifact from 6 to 7](https://github.com/javiertuya/samples-test-spring/pull/383)