### PR TITLE
Combined dependency updates (2026-04-05)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,13 +174,13 @@ jobs:
           cache: 'maven'
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: https://ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Hardened Images Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: https://dhi.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.3.0
+        uses: mikepenz/action-junit-report@v6.4.0
         with:
           check_name: test-report
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -245,7 +245,7 @@ jobs:
         run: mvn test -Dtest=**/st/** -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.3.0
+        uses: mikepenz/action-junit-report@v6.4.0
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -315,7 +315,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.3.0
+        uses: mikepenz/action-junit-report@v6.4.0
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,4 +47,4 @@ jobs:
           path: 'target/reports/testapidocs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<!-- A partir de la 7.20 ha habido muchos problemas para ejecutar con junit 5
 		que impiden descubrir los features, parece que usando 7.19 no aparecen,
 		pero de momento se ejecutara cucumber bajo junit 4 -->
-		<cucumber.version>7.34.2</cucumber.version>
+		<cucumber.version>7.34.3</cucumber.version>
 
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.3</version>
+		<version>4.0.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.springframework.boot:spring-boot-starter-parent from 4.0.3 to 4.0.5](https://github.com/javiertuya/samples-test-spring/pull/396)
- [Bump docker/login-action from 3 to 4](https://github.com/javiertuya/samples-test-spring/pull/395)
- [Bump actions/deploy-pages from 4 to 5](https://github.com/javiertuya/samples-test-spring/pull/394)
- [Bump cucumber.version from 7.34.2 to 7.34.3](https://github.com/javiertuya/samples-test-spring/pull/393)
- [Bump actions/configure-pages from 5 to 6](https://github.com/javiertuya/samples-test-spring/pull/392)
- [Bump mikepenz/action-junit-report from 6.3.0 to 6.4.0](https://github.com/javiertuya/samples-test-spring/pull/391)