### PR TITLE
Combined dependency updates (2026-05-02)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,7 +42,7 @@ jobs:
         run: mvn package -DskipTests=true -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - run: ls -la target/reports
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4.0.0
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: 'target/reports/testapidocs'
       - name: Deploy to GitHub Pages

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
 		<dependency>
 			<groupId>org.jsmart</groupId>
 			<artifactId>zerocode-tdd</artifactId>
-			<version>1.3.47</version>
+			<version>1.4.0</version>
     		<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.41.0</selenium.version>
+		<selenium.version>4.43.0</selenium.version>
 		
 		<!-- A partir de la 7.20 ha habido muchos problemas para ejecutar con junit 5
 		que impiden descubrir los features, parece que usando 7.19 no aparecen,

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.5</version>
+		<version>4.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant-junit</artifactId>
-						<version>1.10.15</version>
+						<version>1.10.17</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.ant</groupId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.seleniumhq.selenium:selenium-java from 4.41.0 to 4.43.0](https://github.com/javiertuya/samples-test-spring/pull/402)
- [Bump org.apache.ant:ant-junit from 1.10.15 to 1.10.17](https://github.com/javiertuya/samples-test-spring/pull/401)
- [Bump org.jsmart:zerocode-tdd from 1.3.47 to 1.4.0](https://github.com/javiertuya/samples-test-spring/pull/400)
- [Bump org.springframework.boot:spring-boot-starter-parent from 4.0.5 to 4.0.6](https://github.com/javiertuya/samples-test-spring/pull/399)
- [Bump actions/upload-pages-artifact from 4.0.0 to 5.0.0](https://github.com/javiertuya/samples-test-spring/pull/398)