### PR TITLE
Combined dependency updates (2026-06-02)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.0
+        uses: mikepenz/action-junit-report@v6.4.1
         with:
           check_name: test-report
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -245,7 +245,7 @@ jobs:
         run: mvn test -Dtest=**/st/** -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.0
+        uses: mikepenz/action-junit-report@v6.4.1
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -315,7 +315,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.0
+        uses: mikepenz/action-junit-report@v6.4.1
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
 		<dependency>
 			<groupId>io.github.javiertuya</groupId>
 			<artifactId>selema</artifactId>
-			<version>4.0.2</version>
+			<version>4.1.0</version>
     		<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
 		
-		<surefire.version>3.5.5</surefire.version>
+		<surefire.version>3.5.6</surefire.version>
 		<!-- removes error flag that appears for some eclipse users -->
 		<maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
 		<!-- required for sonarcloud.io -->

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<!--required here to get the right versions, issue #15-->
-		<selenium.version>4.43.0</selenium.version>
+		<selenium.version>4.44.0</selenium.version>
 		
 		<!-- A partir de la 7.20 ha habido muchos problemas para ejecutar con junit 5
 		que impiden descubrir los features, parece que usando 7.19 no aparecen,

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
 		<dependency>
 			<groupId>org.jsmart</groupId>
 			<artifactId>zerocode-tdd</artifactId>
-			<version>1.4.0</version>
+			<version>1.4.3</version>
     		<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.jsmart:zerocode-tdd from 1.4.0 to 1.4.3](https://github.com/javiertuya/samples-test-spring/pull/408)
- [Bump surefire.version from 3.5.5 to 3.5.6](https://github.com/javiertuya/samples-test-spring/pull/407)
- [Bump io.github.javiertuya:selema from 4.0.2 to 4.1.0](https://github.com/javiertuya/samples-test-spring/pull/406)
- [Bump org.seleniumhq.selenium:selenium-java from 4.43.0 to 4.44.0](https://github.com/javiertuya/samples-test-spring/pull/405)
- [Bump mikepenz/action-junit-report from 6.4.0 to 6.4.1](https://github.com/javiertuya/samples-test-spring/pull/404)