### PR TITLE
Combined dependency updates (2026-07-04)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       #pero suelen tener el problema que con los PR fallan aunque pasen los tests porque no pueden escribir los tests (por motivos de seguridad de Actions)
       - name: Generate test report checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.1
+        uses: mikepenz/action-junit-report@v6.4.2
         with:
           check_name: test-report
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -245,7 +245,7 @@ jobs:
         run: mvn test -Dtest=**/st/** -Dmaven.test.failure.ignore=false -U --no-transfer-progress
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.1
+        uses: mikepenz/action-junit-report@v6.4.2
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'
@@ -315,7 +315,7 @@ jobs:
         run: mvn test -Dtest=TestPostDeploy -Dmaven.test.failure.ignore=false
       - name: Generate post deploy test checks
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.1
+        uses: mikepenz/action-junit-report@v6.4.2
         with:
           check_name: test-report (deploy)
           report_paths: '**/target/*-reports/TEST-*.xml'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     #if: ${{ false }}  # disable for now
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       #Especifica java 17, requerido por Spring Boot 3
       - name: Select Java Version
         uses: actions/setup-java@v5
@@ -98,7 +98,7 @@ jobs:
     if: ${{ false }}  # disable for now (analysis hangs, failing after timeout, July 2025)
     #if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:
@@ -165,7 +165,7 @@ jobs:
         run: echo "APP_NAME=samples-test-spring-develop" >> $GITHUB_ENV
       - run: echo "Deploying to '${{ env.APP_NAME }}'"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:
@@ -285,7 +285,7 @@ jobs:
         run: echo "APP_NAME=samples-test-spring-develop" >> $GITHUB_ENV
       - run: echo "Deploying to '${{ env.APP_NAME }}'"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Select Java Version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       packages: write 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.14</version>
+				<version>0.8.15</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TableColumnAdjuster.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-		<selenium.version>4.44.0</selenium.version>
+		<selenium.version>4.45.0</selenium.version>
 		
 		<playwright.version>1.49.0</playwright.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
 		<selenium.version>4.44.0</selenium.version>
 		
-		<playwright.version>1.49.0</playwright.version>
+		<playwright.version>1.61.0</playwright.version>
 
 		<cucumber.version>7.34.3</cucumber.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		
 		<playwright.version>1.49.0</playwright.version>
 
-		<cucumber.version>7.34.3</cucumber.version>
+		<cucumber.version>7.34.4</cucumber.version>
 
 	</properties>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.microsoft.playwright:playwright from 1.49.0 to 1.61.0](https://github.com/javiertuya/samples-test-spring/pull/416)
- [Bump org.springframework.boot:spring-boot-starter-parent from 4.0.6 to 4.1.0](https://github.com/javiertuya/samples-test-spring/pull/415)
- [Bump cucumber.version from 7.34.3 to 7.34.4](https://github.com/javiertuya/samples-test-spring/pull/414)
- [Bump org.seleniumhq.selenium:selenium-java from 4.44.0 to 4.45.0](https://github.com/javiertuya/samples-test-spring/pull/413)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.14 to 0.8.15](https://github.com/javiertuya/samples-test-spring/pull/412)
- [Bump mikepenz/action-junit-report from 6.4.1 to 6.4.2](https://github.com/javiertuya/samples-test-spring/pull/411)
- [Bump actions/checkout from 6 to 7](https://github.com/javiertuya/samples-test-spring/pull/410)