### PR TITLE
Combined dependency updates (2026-08-03)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v7
       #Especifica java 17, requerido por Spring Boot 3
       - name: Select Java Version
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -100,7 +100,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Select Java Version
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -167,7 +167,7 @@ jobs:
 
       - uses: actions/checkout@v7
       - name: Select Java Version
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -287,7 +287,7 @@ jobs:
 
       - uses: actions/checkout@v7
       - name: Select Java Version
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.4.4
+      - uses: javiertuya/sonarqube-action@v1.4.5
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Select Java Version
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Select Java Version
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		
 		<playwright.version>1.61.0</playwright.version>
 
-		<cucumber.version>7.34.4</cucumber.version>
+		<cucumber.version>7.34.6</cucumber.version>
 
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 		<sonar.organization>giis</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-		<selenium.version>4.45.0</selenium.version>
+		<selenium.version>4.46.0</selenium.version>
 		
 		<playwright.version>1.61.0</playwright.version>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.seleniumhq.selenium:selenium-java from 4.45.0 to 4.46.0](https://github.com/javiertuya/samples-test-spring/pull/421)
- [Bump javiertuya/sonarqube-action from 1.4.4 to 1.4.5](https://github.com/javiertuya/samples-test-spring/pull/420)
- [Bump cucumber.version from 7.34.4 to 7.34.6](https://github.com/javiertuya/samples-test-spring/pull/419)
- [Bump actions/setup-java from 5 to 5.6.0](https://github.com/javiertuya/samples-test-spring/pull/418)